### PR TITLE
use watchify to build React/cjsx on development

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -4,7 +4,6 @@ module.exports = (grunt) ->
 
   require 'coffee-errors'
 
-  grunt.loadNpmTasks 'grunt-contrib-watch'
   grunt.loadNpmTasks 'grunt-browserify'
   grunt.loadNpmTasks 'grunt-contrib-uglify'
   grunt.loadNpmTasks 'grunt-contrib-csslint'
@@ -25,7 +24,7 @@ module.exports = (grunt) ->
     'simplemocha'
   ]
 
-  grunt.registerTask 'default', [ 'build', 'watch' ]
+  grunt.registerTask 'default', [ 'build', 'test' ]
 
   grunt.initConfig
 
@@ -85,22 +84,3 @@ module.exports = (grunt) ->
         ignoreLeaks: no
       dist:
         src: [ 'tests/test_*.coffee' ]
-
-    watch:
-      options:
-        interrupt: yes
-
-      client:
-        options:
-          livereload: yes
-        files: [
-          'client/**/*.{coffee,jsx,cjsx,js,jade}'
-        ]
-        tasks: [ 'build' ]
-
-      server:
-        files: [
-          'server/**/*.{coffee,js,json}'
-          'tests/*.{coffee,js}'
-        ]
-        tasks: [ 'test' ]

--- a/README.md
+++ b/README.md
@@ -26,19 +26,22 @@ REQUIREMENTS
 - MongoDB v2.x
 
 
-BUILD CLIENT-JS
+BUILD CLIENT-JS&JSX
 ---------------
 
     % npm install
-    % npm build
+    % npm run build
 
-    # or
-    % npm run watch
+    # watch client jsx, then build
+    % npm run watchify
+
+    # to deploy, minify js
+    % NODE_ENV=production npm run build
 
 RUN
 ---
 
-    % npm install
+    # start server at port:3000
     % PORT=3000 DEBUG=chat* npm start
 
 

--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
   "scripts": {
     "start": "coffee server/app.coffee",
     "build": "grunt build",
-    "test": "grunt test",
-    "watch": "grunt watch"
+    "watchify": "watchify --verbose --debug --extension=.cjsx --extension=.coffee -t coffee-reactify client/app.cjsx -o public/js/bundle.js",
+    "test": "grunt"
   },
   "author": "Sho Hashimoto <hashimoto@shokai.org>",
   "license": "MIT",
   "dependencies": {
     "body-parser": "*",
+    "browserify": "*",
     "coffee-errors": "*",
-    "coffee-reactify": "^3.0",
+    "coffee-reactify": "*",
     "coffee-script": "^1.9",
     "coffeelint": "*",
     "connect-mongo": "*",
@@ -25,12 +26,11 @@
     "express-session": "*",
     "fluxxor": "^1.5.3",
     "grunt": "*",
-    "grunt-browserify": "^3.7",
+    "grunt-browserify": "*",
     "grunt-cli": "*",
     "grunt-coffeelint": "*",
     "grunt-contrib-csslint": "*",
     "grunt-contrib-uglify": "*",
-    "grunt-contrib-watch": "*",
     "grunt-jsonlint": "*",
     "grunt-notify": "*",
     "grunt-simple-mocha": "*",
@@ -41,7 +41,8 @@
     "react": "^0.13.2",
     "socket.io": "^1.3",
     "socket.io-client": "^1.3",
-    "supertest": "*"
+    "supertest": "*",
+    "watchify": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Gruntfile:
- removed "grunt-contrib-watch" and watch tasks

package.json:
- installed watchify npm
- added command "npm run watchify"

README:
- updated

to release build, use Grunt
